### PR TITLE
add shared fate wrapper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,9 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -o /go/bin/aws-sigv4-proxy
 
-FROM scratch
+FROM alpine:3.7
 COPY --from=build /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/
 COPY --from=build /go/bin/aws-sigv4-proxy /go/bin/aws-sigv4-proxy
+COPY entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT [ "/go/bin/aws-sigv4-proxy" ]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+PROXY_BIN="/go/bin/aws-sigv4-proxy"
+FATE=${FATE:-"standlone"}
+FATE_MOUNT=${FATE_MOUNT:-"/tmp/fate"}
+FATE_FILE=${FATE_FILE:-"${FATE_MOUNT}/main-terminated"}
+
+if [ "${FATE}" == "shared" ]; then
+    echo "Running in shared-fate mode"
+    echo "Proxy will terminate when ${FATE_FILE} is present"
+
+    ${PROXY_BIN} ${@} &
+    PROXY_PID=$!
+
+    while true; do
+        if [[ -f "${FATE_FILE}" ]]; then kill -SIGTERM ${PROXY_PID}; fi
+        sleep 2
+    done &
+
+    wait ${PROXY_PID}
+
+    if [[ -f "${FATE_FILE}" ]]; then exit 0; fi
+else
+    echo "Running in standalone mode"
+    exec ${PROXY_BIN} ${@}
+fi


### PR DESCRIPTION
Reinstates the shared fate wrapper we had in the old version of the signing proxy.
This is needed so that Jobs using the proxy won't get stuck running forever as their sidecar does not terminate.
This is why curator hasn't been working
