### PR TITLE
Airship-3911: fix docker image tag version

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           images: ${{ vars.IMAGE_NAME_DEFAULT }}
           tags: |
-            type=semver,pattern={{raw}}
+            type=semver,pattern={{version}}
             type=sha,prefix=,format=long,
       - uses: docker/build-push-action@v5
         with:


### PR DESCRIPTION
Using {{version}} to drop `v` prefix in tag matching the previous behaviour from drone.